### PR TITLE
cURL keep-alive settings & multi_set with socks [ amazing speed ]

### DIFF
--- a/firebaseLib.php
+++ b/firebaseLib.php
@@ -115,7 +115,7 @@ class Firebase implements FirebaseInterface
     /**
      * Writing multiple datas into multiple Firebase paths with a PUT request via socks
      * $paths[$key] must be pair to $datas[$key]
-     * !! SUPER FAST !! Do not use more than 1000 elements ( depends of elements size, it's not well tested )
+     * !! SUPER FAST !! Do not use more than 200 elements ( depends of elements size, it's not well tested )
      *
      * @param Array $paths List of Paths
      * @param Array $data  List of Values

--- a/firebaseLib.php
+++ b/firebaseLib.php
@@ -248,7 +248,7 @@ class Firebase implements FirebaseInterface
         if($this->_fp)
             $fp = $this->_fp;
         else{
-            $fp = fsockopen($sslUrl,443,$errNo, $errStr, 300);
+            $fp = fsockopen($sslUrl,443,$errNo, $errStr, 30);
             $this->_fp = $fp;
         }
 

--- a/firebaseLib.php
+++ b/firebaseLib.php
@@ -267,7 +267,7 @@ class Firebase implements FirebaseInterface
         $sslUrl = "ssl://".$parts['host'];
         $fp = fsockopen($sslUrl,443,$errNo, $errStr, 30);
 
-        $out = "PUT ".$parts['path']." HTTP/1.1\r\n";
+        $out = "PUT ".$parts['path']."?auth=".$this->_token." HTTP/1.1\r\n";
         $out.= "Host: ".$parts['host']."\r\n";
         $out.= "Content-Type: application/json\r\n";
         $out.= "Content-Length: ".strlen($jsonData)."\r\n";

--- a/firebaseLib.php
+++ b/firebaseLib.php
@@ -111,6 +111,22 @@ class Firebase implements FirebaseInterface
       return $this->_writeData($path, $data, 'PUT');
     }
     /**
+     * Creating multiple curl process with shell_exec, you'll need shell_exec and must run PHP on linux 
+     * 
+     *
+     * @param String $path Path
+     * @param Mixed  $data Data
+     *
+     * @return Nothing be careful
+     */
+    public function set_fast($path,$data)
+    {
+        if (strtoupper(substr(PHP_OS, 0, 3)) === 'WIN') {
+            return $this->_writeData($path, $data, 'PUT');
+        }
+        $this->_execPut($path,$data);
+    }
+    /**
      * Writing multiple datas into multiple Firebase paths with a PUT request via socks
      * $paths[$key] must be pair to $datas[$key]
      *
@@ -234,6 +250,13 @@ class Firebase implements FirebaseInterface
             $return = null;
         }
         return $return;
+    }
+    private function _execPut($path,$data)
+    {
+        $path = $this->_getJsonPath($path);
+
+        $formatted_data = addslashes(json_encode($data));
+        shell_exec("curl -X PUT -d $formatted_data  \"$path\" > /dev/null 2>/dev/null &");
     }
     private function _socksPut($path,$data)
     {


### PR DESCRIPTION
Added multi_set with socks, when i tried its performance on setting 100
minimal data to 100 different path; it's %50-70 faster than cURL put
request.

usage :

$firebase->set_multi($paths,$datas);
// $paths[$key] and $datas[$key] must be pair.

Added parallel set with shell_exec, it gives amazing speed but cause no control or debug feature.

> Be careful it contains shell_exec method and json_data ( may contains your user inputs ).
> so if you are not trusting to data, I suggest you to sanitize it carefully.

some stats (on digitalocean vps - ubuntu 12.04 ):
50 set request with set method [ it using cURL ]=> 30sec
50 set requests with set_multi method [ it using fsocks ] => 12 sec
50 set requests with set_fast method [ it using cURL with shell exec /
parallel ] => 0.4 sec
