### PR TITLE
Uncapitalize keyword in lib/firebaseStub.php

### DIFF
--- a/lib/firebaseStub.php
+++ b/lib/firebaseStub.php
@@ -107,7 +107,7 @@ class FirebaseStub
     private function _getDeleteResponse() { return $this->_getGetResponse(); }
 }
 
-Class Error {
+class Error {
   function __construct($error, $message)
   {
     $this->error = $error;


### PR DESCRIPTION
Please correct me if I'm wrong, but isn't `class` common practice? :smiley: 