### PR TITLE
Added JSON_FORCE_OBJECT on encoding request.

### DIFF
--- a/src/firebaseLib.php
+++ b/src/firebaseLib.php
@@ -202,7 +202,7 @@ class FirebaseLib implements FirebaseInterface
 
     private function _writeData($path, $data, $method = 'PUT')
     {
-        $jsonData = json_encode($data);
+        $jsonData = json_encode($data, JSON_FORCE_OBJECT);
         $header = array(
             'Content-Type: application/json',
             'Content-Length: ' . strlen($jsonData)


### PR DESCRIPTION
Added JSON_FORCE_OBJECT when encoding request to firebase api to ensure indexes are retained.

ex: 
* `['1'=>"test"]` will be encoded as `{"1":"test"}`
* `['0'=>"test"]` will be encoded as `["test"]` (need it to be `{"0":"test"}`)

