### PR TITLE
Added missing extension dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
   ],
   "license": "MIT",
   "require": {
-    "php": ">=5.3.0"
+    "php": ">=5.3.0",
+    "ext-curl": "*"
   },
   "autoload": {
     "classmap": ["src"]


### PR DESCRIPTION
By default this library needs the curl extension installed. Actually this library just throw an exception when curl is not loaded.