### PR TITLE
[PR] Adds function making it possible to get curl response info

### DIFF
--- a/src/firebaseLib.php
+++ b/src/firebaseLib.php
@@ -111,6 +111,16 @@ class FirebaseLib implements FirebaseInterface
         return $url . $path . '.json?' . http_build_query($options);
     }
 
+	/**
+	 * Gets info for the last request made
+	 *
+	 * @return array details from curl_getinfo
+	 */
+	public function getResponseInfo()
+	{
+		return curl_getinfo($this->_curlHandler);
+	}
+
     /**
      * Sets REST call timeout in seconds
      *


### PR DESCRIPTION
There was no way for us to know previously whether a set call returned with an HTTP code of 200. This allows the code, among other things, to be checked and actions to be taken if a set failed.