### PR TITLE
Redundant require lines removed

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -7,7 +7,7 @@ platform:
 
 steps:
 - name: api
-  image: php
+  image: php:7
   commands:
   - apt-get update
   - apt-get install -y git

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
 
 [![Visual Source](https://img.shields.io/badge/visual-source-orange)](http://www.visualsource.net/repo/github.com/ktamas77/firebase-php)
 
+[:heart: Sponsor](https://github.com/sponsors/ktamas77)
+
 Based on the [Firebase REST API](https://www.firebase.com/docs/rest-api.html).
 
 Available on [Packagist](https://packagist.org/packages/ktamas77/firebase-php).
@@ -29,7 +31,9 @@ const DEFAULT_URL = 'https://kidsplace.firebaseio.com/';
 const DEFAULT_TOKEN = 'MqL0c8tKCtheLSYcygYNtGhU8Z2hULOFs9OKPdEp';
 const DEFAULT_PATH = '/firebase/example';
 
-$firebase = new \Firebase\FirebaseLib(DEFAULT_URL, DEFAULT_TOKEN);
+use Firebase\FirebaseLib;
+
+$firebase = new FirebaseLib(DEFAULT_URL, DEFAULT_TOKEN);
 
 // --- storing an array ---
 $test = [

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "REST",
     "wrapper"
   ],
-  "version": "2.2.2",
+  "version": "2.2.4",
   "authors": [
     {
       "name": "Tamas Kalman",

--- a/src/firebaseError.php
+++ b/src/firebaseError.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Firebase;
 
 /**

--- a/src/firebaseInterface.php
+++ b/src/firebaseInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Firebase;
 
 /**

--- a/src/firebaseLib.php
+++ b/src/firebaseLib.php
@@ -1,7 +1,6 @@
 <?php
-namespace Firebase;
 
-require_once __DIR__ . '/firebaseInterface.php';
+namespace Firebase;
 
 use Exception;
 

--- a/src/firebaseStub.php
+++ b/src/firebaseStub.php
@@ -2,9 +2,6 @@
 
 namespace Firebase;
 
-require_once __DIR__ . '/firebaseError.php';
-require_once __DIR__ . '/firebaseInterface.php';
-
 /**
  * Class FirebaseStub
  *

--- a/tests/firebaseStubTest.php
+++ b/tests/firebaseStubTest.php
@@ -1,9 +1,10 @@
 <?php
+
 namespace Firebase;
 
-require_once __DIR__ . '/../src/firebaseStub.php';
+use PHPUnit_Framework_TestCase;
 
-class FirebaseStubTest extends \PHPUnit_Framework_TestCase
+class FirebaseStubTest extends PHPUnit_Framework_TestCase
 {
     /**
      * @var FirebaseStub

--- a/tests/firebaseTest.php
+++ b/tests/firebaseTest.php
@@ -2,11 +2,10 @@
 
 namespace Firebase;
 
-require_once __DIR__ . '/../src/firebaseLib.php';
-
 use Exception;
+use PHPUnit_Framework_TestCase;
 
-class FirebaseTest extends \PHPUnit_Framework_TestCase
+class FirebaseTest extends PHPUnit_Framework_TestCase
 {
     protected $firebase;
     protected $todoMilk = array(


### PR DESCRIPTION
Since namespace is properly loaded in the autoloader, we don't need to require the files explicitly.